### PR TITLE
new react bundle generatino routine

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ Set the `minimum-stability` in your composer.json to `dev`
 ... 
 "scripts": {
 "regenerate_react_bundle": [
-    "vendor/b-tokman/yii2-react/node_modules/.bin/browserify vendor/b-tokman/yii2-react/build-react-bundle.js > vendor/b-tokman/yii2-react/lib/assets/react-bundle.js",
-    "vendor/b-tokman/yii2-react/node_modules/.bin/uglifyjs  vendor/b-tokman/yii2-react/lib/assets/react-bundle.js -c -m -o vendor/b-tokman/yii2-react/lib/assets/react-bundle.min.js"
+    "vendor/b-tokman/yii2-react/build-bundles.sh"
 ],
 "post-install-cmd":[
     "@regenerate_react_bundle",

--- a/build-bundles.sh
+++ b/build-bundles.sh
@@ -1,0 +1,18 @@
+#This script will build latest REACT production and development bundles
+#Meant to be run from composer post-install-cm and post-update-cmd
+#!/bin/bash
+OLD_PWD=$PWD
+SCRIPT=`realpath $0`
+SCRIPTPATH=`dirname $SCRIPT`
+#Add path to vendor/bin/ directory, where npm and node located. it should allready be there, if we run from composer, but, just in case...
+export PATH="$PATH:$SCRIPTPATH/../../bin"
+
+cd $SCRIPTPATH
+
+#Build development bundle.
+./node_modules/.bin/browserify ./build-react-bundle.js > ./lib/assets/react-bundle.js
+
+#build production bundle.
+./node_modules/.bin/browserify  ./build-react-bundle.js -g [ envify --NODE_ENV production ] -g uglifyify | ./node_modules/.bin/terser --compress --mangle > ./lib/assets/react-bundle.min.js
+#Going back where we are at launch
+cd $PWD

--- a/composer.json
+++ b/composer.json
@@ -23,16 +23,15 @@
     "require-npm": {
       "react": "*",
       "react-dom":"*",
-      "browserify": "^16",
       "envify": "*",
       "terser": "*",
+      "browserify": "^16",
       "uglifyify": "*"
     }
   },
   "scripts": {
     "regenerate_react_bundle": [
-      "node_modules/.bin/browserify build-react-bundle.js > lib/assets/react-bundle.js",
-      "node_modules/.bin/browserify build-react-bundle.js -g [ envify --NODE_ENV production ] -g uglifyify | terser --compress --mangle > lib/assets/react-bundle.min.js"
+      "./build-bundles.sh"
     ],
     "post-install-cmd": "@regenerate_react_bundle",
     "post-update-cmd": "@regenerate_react_bundle"

--- a/composer.json
+++ b/composer.json
@@ -24,13 +24,15 @@
       "react": "*",
       "react-dom":"*",
       "browserify": "^16",
-      "uglify-js":"*"
+      "envify": "*",
+      "terser": "*",
+      "uglifyify": "*"
     }
   },
   "scripts": {
     "regenerate_react_bundle": [
       "node_modules/.bin/browserify build-react-bundle.js > lib/assets/react-bundle.js",
-      "node_modules/.bin/uglifyjs  lib/assets/react-bundle.js -c -m -o lib/assets/react-bundle.min.js"
+      "node_modules/.bin/browserify build-react-bundle.js -g [ envify --NODE_ENV production ] -g uglifyify | terser --compress --mangle > lib/assets/react-bundle.min.js"
     ],
     "post-install-cmd": "@regenerate_react_bundle",
     "post-update-cmd": "@regenerate_react_bundle"

--- a/lib/widgets/ReactRenderer.php
+++ b/lib/widgets/ReactRenderer.php
@@ -184,7 +184,7 @@ class ReactRenderer extends Widget
 		$this->js = file_get_contents($this->componentsSourceJs);
 	    }
 	}
-        return $this->js;;
+        return $this->js;
     }
 
 


### PR DESCRIPTION
changed production bundle generation by browserify to use envify, uglifyify and terser. This is correct bundle build scenario, this way react-bundle.min.js gets only 149kb of size. 